### PR TITLE
NOISSUE - Replace deprecated instrumentation method

### DIFF
--- a/internal/server/grpc/grpc.go
+++ b/internal/server/grpc/grpc.go
@@ -52,7 +52,7 @@ func New(ctx context.Context, cancel context.CancelFunc, name string, config ser
 func (s *Server) Start() error {
 	errCh := make(chan error)
 	grpcServerOptions := []grpc.ServerOption{
-		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	}
 
 	listener, err := net.Listen("tcp", s.Address)


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--
For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is an update that replaces the unitary grpc interceptor method on grpc options

<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
Replaced the gRPC server's UnaryInterceptor with StatsHandler from the otelgrpc package for enhanced monitoring capabilities, aligning with best practices for observability. This update allows us to take full advantage of OpenTelemetry's metrics and traces, thereby improving insight into our gRPC server's performance and reliability.

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->
None

## Have you included tests for your changes?
No, this does not change functionality or add new methods

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
No, no functionality was changed

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
