### PR TITLE
NOISSUE - Replace deprecated gRPC metrics collection with new stats handler

### DIFF
--- a/pkg/auth/connect.go
+++ b/pkg/auth/connect.go
@@ -101,7 +101,7 @@ func (c *client) Secure() string {
 // connect creates new gRPC client and connect to gRPC server.
 func connect(cfg Config) (*grpc.ClientConn, security, error) {
 	opts := []grpc.DialOption{
-		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 	secure := withoutTLS
 	tc := insecure.NewCredentials()


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix as it replaces the deprecated grpc tracing method.

## What does this do?

Replace deprecated unary interceptor with stats handler
## Which issue(s) does this PR fix/relate to?

No issue

## Have you included tests for your changes?

No change in functionality hence no tests
## Did you document any new/modified feature?

No since it only updates deprecated code

### Notes

NA
